### PR TITLE
Add etherlink testnet bridge

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -61,6 +61,7 @@ View realtime and historical block data
 Crypto onramps to Etherlink
 
 -   [Etherlink Bridge](https://bridge.etherlink.com/)
+-   [Etherlink Testnet Bridge](https://bridge-xi.vercel.app/)
 
 ## DeFi
 


### PR DESCRIPTION
Actually, there is not possibility to access to the testnet with the official Etherlink bridge since its upgrade, so we have to use the old one that I added. It is working, just a little bit less cool but it will do the job while the team fix it.